### PR TITLE
修复Lagrange中群聊合并转发信息中图片的发送

### DIFF
--- a/onebot/src/main/kotlin/cn/evolvefield/onebot/client/core/Bot.kt
+++ b/onebot/src/main/kotlin/cn/evolvefield/onebot/client/core/Bot.kt
@@ -921,6 +921,23 @@ class Bot(
         return result.withToken()
     }
     /**
+     * 发送合并转发 (群)
+     *
+     * @param groupId 群号
+     * @param msg     自定义转发消息
+     * [参考文档](https://lagrangedev.github.io/Lagrange.Doc/Lagrange.OneBot/API/Extend/#%E5%8F%91%E9%80%81%E5%90%88%E5%B9%B6%E8%BD%AC%E5%8F%91-%E7%BE%A4%E8%81%8A)
+     * @return [ActionData]
+     */
+    suspend fun sendGroupForwardMsgLagrange(groupId: Long, msg: List<Map<String, Any>>): ActionData<String?> {
+        val action = ActionPathEnum.SEND_GROUP_FORWARD_MSG
+        val params = JsonObject()
+        params.addProperty("group_id", groupId)
+        params.add("messages", msg.toJsonArray())
+
+        val result = actionHandler.action(this, action, params)
+        return result.withToken()
+    }
+    /**
      * 获取群根目录文件列表
      *
      * @param groupId 群号

--- a/overflow-core/src/main/kotlin/top/mrxiaom/overflow/internal/message/OnebotMessages.kt
+++ b/overflow-core/src/main/kotlin/top/mrxiaom/overflow/internal/message/OnebotMessages.kt
@@ -176,7 +176,10 @@ internal object OnebotMessages {
         val nodes = serializeForwardNodes(bot, forward.nodeList)
         when (bot.appName.lowercase()) {
             "lagrange.onebot" -> {
-                val resId = bot.impl.sendForwardMsgLagrange(nodes).data
+                val resId = when (contact) {
+                    is Group -> bot.impl.sendGroupForwardMsgLagrange(contact.id, nodes).data
+                    else -> bot.impl.sendForwardMsgLagrange(nodes).data
+                }
                 if (resId != null) {
                     val forwardMsg = Json.encodeToString(buildJsonArray {
                         addJsonObject {


### PR DESCRIPTION
**在提出此拉取请求时，我确认了以下几点（请复选框）：**

- [x] 我已阅读并理解[贡献文档](https://github.com/MrXiaoM/Overflow/tree/main/docs/contributing)。
- [x] 我已检查没有与此请求重复的 Pull Requests。
- [x] 我已经考虑过，并确认这份呈件对其他人很有价值。
- [x] 我接受此提交可能不会被使用，并根据维护人员的意愿关闭 Pull Requests。

<!-- 以上任意一项未勾选，Pull Requests 将会被无理由关闭，[x] 为已勾选，[ ] 为未勾选 -->
<!-- 以上任意一项未勾选，Pull Requests 将会被无理由关闭，[x] 为已勾选，[ ] 为未勾选 -->
<!-- 以上任意一项未勾选，Pull Requests 将会被无理由关闭，[x] 为已勾选，[ ] 为未勾选 -->

**填写PR内容：**
目前Lagrange的`send_forward_msg`是以私聊的方式创建合并转发信息，因此其图片不能在群聊中正常加载

会导致以下效果：
![82c0f79c73df9913eca9434301ec6f7](https://github.com/KonataDev/Lagrange.Core/assets/92856393/e63de966-36fd-4af7-9098-8c15ea4b8b46)

