### PR TITLE
允许用户通过指令执行OnebotAPI

### DIFF
--- a/overflow-core/src/main/kotlin/top/mrxiaom/overflow/internal/plugin/OverflowCoreAsPlugin.kt
+++ b/overflow-core/src/main/kotlin/top/mrxiaom/overflow/internal/plugin/OverflowCoreAsPlugin.kt
@@ -27,6 +27,7 @@ import net.mamoe.mirai.utils.weeksToMillis
 import org.java_websocket.client.WebSocketClient
 import org.slf4j.Logger
 import top.mrxiaom.overflow.OverflowAPI
+import top.mrxiaom.overflow.contact.RemoteBot
 import top.mrxiaom.overflow.contact.RemoteBot.Companion.asRemoteBot
 import top.mrxiaom.overflow.event.UnsolvedOnebotEvent
 import top.mrxiaom.overflow.internal.Overflow
@@ -128,6 +129,17 @@ internal object OverflowCoreAsPlugin : Plugin, CommandOwner {
                     (it.asOnebot.impl.channel as? WebSocketClient)?.reconnectBlocking()
                 }
                 sendMessage("重新连接执行完成")
+            }
+           @SubCommand
+            @Description("调用API")
+            suspend fun CommandSender.exec(
+                @Name("API请求路径") apiPath: String,
+                @Name("请求参数") params :String?
+            ) {
+                val bot = (Bot.instances.firstOrNull() as RemoteBot) ?: return Unit.also {
+                    sendMessage("至少有一个Bot在线才能执行该命令")
+                }
+                sendMessage(bot.executeAction(apiPath,params))
             }
             @SubCommand
             @Description("发送群消息")


### PR DESCRIPTION
**在提出此拉取请求时，我确认了以下几点（请复选框）：**

- [x] 我已阅读并理解[贡献文档](https://github.com/MrXiaoM/Overflow/tree/main/docs/contributing)。
- [x] 我已检查没有与此请求重复的 Pull Requests。
- [x] 我已经考虑过，并确认这份呈件对其他人很有价值。
- [x] 我接受此提交可能不会被使用，并根据维护人员的意愿关闭 Pull Requests。

<!-- 以上任意一项未勾选，Pull Requests 将会被无理由关闭，[x] 为已勾选，[ ] 为未勾选 -->
<!-- 以上任意一项未勾选，Pull Requests 将会被无理由关闭，[x] 为已勾选，[ ] 为未勾选 -->
<!-- 以上任意一项未勾选，Pull Requests 将会被无理由关闭，[x] 为已勾选，[ ] 为未勾选 -->

**填写PR内容：**
允许用户通过指令执行OnebotAPI，使其更有灵活性，延展性，不仅用户可以使用，也可供[CommandYouWant](https://github.com/MrXiaoM/CommandYouWant)之类的插件使用

