### PR TITLE
修复`Lagrange`回复下的`chat-command`使用

### DIFF
--- a/overflow-core/src/main/kotlin/top/mrxiaom/overflow/internal/message/OnebotMessages.kt
+++ b/overflow-core/src/main/kotlin/top/mrxiaom/overflow/internal/message/OnebotMessages.kt
@@ -232,7 +232,10 @@ internal object OnebotMessages {
             if (source != null) add(source)
 
             val app = bot.appName.lowercase()
-            for (o in json) {
+
+            var hasQuote = false
+
+            for ((i, o) in json.withIndex()) {
                 val obj = o.jsonObject
                 val type = obj["type"].string
                 val data = obj["data"]?.jsonObject ?: buildJsonObject {  }
@@ -252,6 +255,8 @@ internal object OnebotMessages {
                         "record" -> add(audioFromFile(data["file"].string))
                         "video" -> add(videoFromFile(data["file"].string))
                         "at" -> {
+                            if (i == 1 && hasQuote)
+                                continue
                             if (data["qq"].string.lowercase() == "all")
                                 add(AtAll)
                             else
@@ -323,6 +328,11 @@ internal object OnebotMessages {
                                 .messages { deserializeFromOneBot(bot, msgData.message) }
                                 .time(msgData.time)
                             val kind = if (msgData?.groupId == 0L) MessageSourceKind.FRIEND else MessageSourceKind.GROUP
+
+                            // lagrange
+                            if (i == 0 && app == "lagrange.onebot") {
+                                hasQuote = true
+                            }
 
                             add(QuoteReply(msgSource.build(bot.id, kind)))
                         }


### PR DESCRIPTION
**在提出此拉取请求时，我确认了以下几点（请复选框）：**

- [x] 我已阅读并理解[贡献文档](https://github.com/MrXiaoM/Overflow/tree/main/docs/contributing)。
- [x] 我已检查没有与此请求重复的 Pull Requests。
- [x] 我已经考虑过，并确认这份呈件对其他人很有价值。
- [x] 我接受此提交可能不会被使用，并根据维护人员的意愿关闭 Pull Requests。

<!-- 以上任意一项未勾选，Pull Requests 将会被无理由关闭，[x] 为已勾选，[ ] 为未勾选 -->
<!-- 以上任意一项未勾选，Pull Requests 将会被无理由关闭，[x] 为已勾选，[ ] 为未勾选 -->
<!-- 以上任意一项未勾选，Pull Requests 将会被无理由关闭，[x] 为已勾选，[ ] 为未勾选 -->

**填写PR内容：**
目前Lagrange获取到的QQNT消息段中，回复中必会跟随一个At，https://github.com/LagrangeDev/Lagrange.Core/issues/266#issuecomment-2124016893

Lagrange方应该一时半会儿没法修这个东西，因此尝试在Overflow中忽略多余的At来让chat-command正常执行


