### PR TITLE
修复在对接 LLOneBot 时群组消息 QuoteReply.targetId 为 0

### DIFF
--- a/overflow-core/src/main/kotlin/top/mrxiaom/overflow/internal/message/OnebotMessages.kt
+++ b/overflow-core/src/main/kotlin/top/mrxiaom/overflow/internal/message/OnebotMessages.kt
@@ -413,7 +413,7 @@ internal object OnebotMessages {
                                 .internalId(id)
                             if (msgData != null) msgSource
                                 .sender(msgData.sender.userId.toLong())
-                                .target(msgData.targetId)
+                                .target(msgData.groupId.takeIf { it != 0L }?:msgData.targetId)  // LLOneBot 没有提供 targetId
                                 .messages(toMiraiMessage(msgData.isJsonMessage, msgData.message, bot) as Iterable<Message>)
                                 .time(msgData.time)
                             val kind = if (msgData?.groupId == 0L) MessageSourceKind.FRIEND else MessageSourceKind.GROUP


### PR DESCRIPTION
**在提出此拉取请求时，我确认了以下几点（请复选框）：**

- [x] 我已阅读并理解[贡献文档](https://github.com/MrXiaoM/Overflow/tree/main/docs/contributing)。
- [x] 我已检查没有与此请求重复的 Pull Requests。
- [x] 我已经考虑过，并确认这份呈件对其他人很有价值。
- [x] 我接受此提交可能不会被使用，并根据维护人员的意愿关闭 Pull Requests。

**填写PR内容：**
对接LLOneBot的过程中发现 `get_msg` API 中他并没有提供targetId字段，但是反序列化 `reply` 时是需要该字段的。

```json
{
    "status": "ok",
    "retcode": 0,
    "data": {
        "self_id": 123456789,
        "user_id": 123456789,
        "time": 1723389216,
        "message_id": -2222222222,
        "real_id": -2222222222,
        "message_seq": -2222222222,
        "message_type": "group",
        "sender": {
            "user_id": 123456789,
            "nickname": "xxxx",
            "card": "",
            "role": "owner"
        },
        "raw_message": "1",
        "font": 14,
        "sub_type": "normal",
        "message": [
            {
                "data": {
                    "text": "1"
                },
                "type": "text"
            }
        ],
        "message_format": "array",
        "post_type": "message_sent",
        "group_id": 987654321
    },
    "message": "",
    "wording": "",
    "echo": 5
}
```

现在单纯改了下判断groupId不为0则 set 进 `targetId`。

暂时就是验证了一下 LLOneBot，其他端还未验证。

