### PR TITLE
支持反向WebSocket多实例

### DIFF
--- a/onebot/build.gradle.kts
+++ b/onebot/build.gradle.kts
@@ -16,6 +16,10 @@ setupMavenCentralPublication {
     artifact(tasks.getByName("dokkaJavadocJar"))
 }
 
+tasks.test {
+    useJUnitPlatform()
+}
+
 dependencies {
     implementation("org.projectlombok:lombok:1.18.26")
     implementation("com.google.code.gson:gson:2.10.1")
@@ -27,6 +31,7 @@ dependencies {
 
     annotationProcessor("org.java-websocket:Java-WebSocket:1.5.7")
     annotationProcessor("org.projectlombok:lombok:1.18.26")
-
     testCompileOnly("org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm:1.6.4")
+    testImplementation("org.junit.jupiter:junit-jupiter:5.8.1")
+    testImplementation(kotlin("test"))
 }

--- a/onebot/src/main/kotlin/client/config/BotConfig.kt
+++ b/onebot/src/main/kotlin/client/config/BotConfig.kt
@@ -48,4 +48,6 @@ class BotConfig(
      */
     val retryRestMills: Long = 60000L,
     val parentJob: Job? = null
-)
+) {
+    val isInReverseMode get() = reversedPort in 1..65535
+}

--- a/onebot/src/main/kotlin/client/connection/ConnectFactory.kt
+++ b/onebot/src/main/kotlin/client/connection/ConnectFactory.kt
@@ -95,7 +95,7 @@ class ConnectFactory private constructor(
     }
 
     @JvmOverloads
-    suspend fun createProducer(
+    fun createProducer(
         scope: CoroutineScope = CoroutineScope(CoroutineName("ConnectFactory"))
     ): OneBotProducer {
         if (config.isInReverseMode) {

--- a/onebot/src/main/kotlin/client/connection/platform-connection.kt
+++ b/onebot/src/main/kotlin/client/connection/platform-connection.kt
@@ -5,10 +5,16 @@ import kotlinx.coroutines.withTimeout
 import kotlin.time.Duration
 
 interface OneBotProducer {
+    fun invokeOnClose(block: () -> Unit)
+    fun close()
     suspend fun awaitNewBotConnection(duration: Duration = Duration.INFINITE): Bot?
 }
 
 class PositiveOneBotProducer(private val client: WSClient) : OneBotProducer {
+    override fun invokeOnClose(block: () -> Unit) = TODO("客户端暂不支持断线重连")
+
+    override fun close() = client.close()
+
     override suspend fun awaitNewBotConnection(duration: Duration): Bot? {
         return kotlin.runCatching {
             withTimeout(duration) {
@@ -19,6 +25,12 @@ class PositiveOneBotProducer(private val client: WSClient) : OneBotProducer {
 }
 
 class ReversedOneBotProducer(private val server: WSServer) : OneBotProducer {
+    override fun invokeOnClose(block: () -> Unit) {
+        server.closeHandler.add(block)
+    }
+
+    override fun close() = server.stop()
+
     override suspend fun awaitNewBotConnection(duration: Duration): Bot? {
         return kotlin.runCatching {
             withTimeout(duration) {

--- a/onebot/src/main/kotlin/client/connection/platform-connection.kt
+++ b/onebot/src/main/kotlin/client/connection/platform-connection.kt
@@ -1,0 +1,29 @@
+package cn.evolvefield.onebot.client.connection
+
+import cn.evolvefield.onebot.client.core.Bot
+import kotlinx.coroutines.withTimeout
+import kotlin.time.Duration
+
+interface OneBotProducer {
+    suspend fun awaitNewBotConnection(duration: Duration = Duration.INFINITE): Bot?
+}
+
+class PositiveOneBotProducer(private val client: WSClient) : OneBotProducer {
+    override suspend fun awaitNewBotConnection(duration: Duration): Bot? {
+        return kotlin.runCatching {
+            withTimeout(duration) {
+                if (client.connectSuspend()) client.createBot() else null
+            }
+        }.getOrNull()
+    }
+}
+
+class ReversedOneBotProducer(private val server: WSServer) : OneBotProducer {
+    override suspend fun awaitNewBotConnection(duration: Duration): Bot? {
+        return kotlin.runCatching {
+            withTimeout(duration) {
+                server.awaitNewBot()
+            }
+        }.getOrNull()
+    }
+}

--- a/onebot/src/test/java/client/connection/OneBotProducerTest.kt
+++ b/onebot/src/test/java/client/connection/OneBotProducerTest.kt
@@ -64,4 +64,22 @@ class OneBotProducerTest {
         }
         jobs.join()
     }
+    @Test
+    fun `should be called when server closing`(): Unit = runBlocking {
+        val factory = ConnectFactory.create(
+            BotConfig(
+                reversedPort = 3001
+            )
+        ).createProducer()
+
+        val defer = CompletableDeferred<Unit>()
+        factory.invokeOnClose {
+            defer.complete(Unit)
+        }
+        launch {
+            delay(3.seconds)
+            factory.close()
+        }
+        defer.join()
+    }
 }

--- a/onebot/src/test/java/client/connection/OneBotProducerTest.kt
+++ b/onebot/src/test/java/client/connection/OneBotProducerTest.kt
@@ -1,0 +1,67 @@
+package client.connection
+
+import cn.evolvefield.onebot.client.config.BotConfig
+import cn.evolvefield.onebot.client.connection.ConnectFactory
+import kotlinx.coroutines.*
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+import kotlin.time.Duration.Companion.seconds
+
+class OneBotProducerTest {
+
+    @Test
+    fun `positive connection should be connect once`(): Unit = runBlocking {
+        val job1 = launch {
+            ConnectFactory.create(
+                BotConfig(
+                    reversedPort = 3001
+                )
+            ).createProducer()
+            delay(30.seconds)
+        }
+        delay(1.seconds)
+        val botConfig = BotConfig(
+            url = "ws://localhost:3001",
+        )
+        val service = ConnectFactory.create(botConfig, botConfig.parentJob).createProducer(this)
+
+        val conn = service.awaitNewBotConnection(duration = 5.seconds)
+        assertNotNull(conn)
+        println("连接：${conn}")
+        assertNull(service.awaitNewBotConnection())
+        job1.cancel()
+    }
+
+    @Test
+    fun `reversed connection should be connect success`(): Unit = runBlocking(Dispatchers.IO) {
+        val server = ConnectFactory.create(
+            BotConfig(
+                reversedPort = 3001
+            )
+        ).createProducer()
+
+
+        val jobs = launch {
+            delay(1.seconds)
+            val botConfig = BotConfig(
+                url = "ws://localhost:3001",
+            )
+            val mockBotInstance = ConnectFactory.create(botConfig, botConfig.parentJob)
+            for (i in 1..3) {
+                mockBotInstance.createProducer(this).awaitNewBotConnection().apply {
+                    println("连接被处理：${this}")
+                }
+                delay(1.seconds)
+            }
+        }
+
+        launch {
+            repeat(3) {
+                val receivedBot = server.awaitNewBotConnection()
+                println("有新连接: $receivedBot")
+            }
+            jobs.cancel()
+        }
+        jobs.join()
+    }
+}

--- a/overflow-core-api/build.gradle.kts
+++ b/overflow-core-api/build.gradle.kts
@@ -33,10 +33,6 @@ setupMavenCentralPublication {
     artifact(tasks.getByName("dokkaJavadocJar"))
 }
 
-tasks.test {
-    useJUnitPlatform()
-}
-
 dependencies {
     implementation(platform("net.mamoe:mirai-bom:$miraiVersion"))
 
@@ -46,5 +42,4 @@ dependencies {
     implementation("me.him188:kotlin-jvm-blocking-bridge-runtime:3.0.0-180.1")
 
     implementation("org.slf4j:slf4j-api:2.0.5")
-    testImplementation("org.junit.jupiter:junit-jupiter:5.8.1")
 }

--- a/overflow-core-api/build.gradle.kts
+++ b/overflow-core-api/build.gradle.kts
@@ -33,6 +33,10 @@ setupMavenCentralPublication {
     artifact(tasks.getByName("dokkaJavadocJar"))
 }
 
+tasks.test {
+    useJUnitPlatform()
+}
+
 dependencies {
     implementation(platform("net.mamoe:mirai-bom:$miraiVersion"))
 
@@ -42,4 +46,5 @@ dependencies {
     implementation("me.him188:kotlin-jvm-blocking-bridge-runtime:3.0.0-180.1")
 
     implementation("org.slf4j:slf4j-api:2.0.5")
+    testImplementation("org.junit.jupiter:junit-jupiter:5.8.1")
 }

--- a/overflow-core-api/src/main/kotlin/top/mrxiaom/overflow/BotBuilder.kt
+++ b/overflow-core-api/src/main/kotlin/top/mrxiaom/overflow/BotBuilder.kt
@@ -183,8 +183,8 @@ public class BotBuilder private constructor(
     }
 }
 
-public interface IBotStarter {
-    public suspend fun start(
+interface IBotStarter {
+    suspend fun start(
         url: String,
         reversedPort: Int,
         token: String,

--- a/overflow-core/build.gradle.kts
+++ b/overflow-core/build.gradle.kts
@@ -33,6 +33,11 @@ dependencies {
     testImplementation("org.java-websocket:Java-WebSocket:1.5.7")
     testImplementation("net.mamoe:mirai-console")
     testImplementation("net.mamoe:mirai-console-terminal")
+    testImplementation("org.junit.jupiter:junit-jupiter:5.8.1")
+}
+
+tasks.test {
+    useJUnitPlatform()
 }
 
 tasks {

--- a/overflow-core/src/main/kotlin/top/mrxiaom/overflow/internal/Overflow.kt
+++ b/overflow-core/src/main/kotlin/top/mrxiaom/overflow/internal/Overflow.kt
@@ -238,7 +238,7 @@ class Overflow : IMirai, CoroutineScope, LowLevelApiAccessor, OverflowAPI {
 
         val factory = ConnectFactory.create(botConfig, botConfig.parentJob, logger)
         val service = if (botConfig.isInReverseMode) {
-            val saved = reverseServerConfig[botConfig.reversedPort]?.also {
+            reverseServerConfig[botConfig.reversedPort]?.also {
                 if (printInfo) logger.warn("在相同的端口 (${botConfig.reversedPort}) 上寻找到已创建的 ConnectFactory，已复用已有配置。")
             } ?: factory.createProducer().apply {
                 invokeOnClose {

--- a/overflow-core/src/main/kotlin/top/mrxiaom/overflow/internal/Overflow.kt
+++ b/overflow-core/src/main/kotlin/top/mrxiaom/overflow/internal/Overflow.kt
@@ -174,7 +174,7 @@ class Overflow : IMirai, CoroutineScope, LowLevelApiAccessor, OverflowAPI {
         try {
             Class.forName("net.mamoe.mirai.console.MiraiConsole")
             miraiConsoleFlag = true
-//            injectMiraiConsole()
+            injectMiraiConsole()
         } catch (ignored: ClassNotFoundException) {
         }
         launch {

--- a/overflow-core/src/test/kotlin/BotBuilderTest.kt
+++ b/overflow-core/src/test/kotlin/BotBuilderTest.kt
@@ -1,0 +1,66 @@
+import cn.evolvefield.onebot.client.handler.ActionHandler
+import com.google.gson.Gson
+import com.google.gson.JsonObject
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import org.java_websocket.WebSocket
+import org.java_websocket.handshake.ClientHandshake
+import org.java_websocket.server.WebSocketServer
+import org.junit.jupiter.api.Test
+import top.mrxiaom.overflow.BotBuilder
+import java.lang.Exception
+import java.net.InetSocketAddress
+import kotlin.coroutines.resume
+import kotlin.coroutines.suspendCoroutine
+import kotlin.time.Duration.Companion.seconds
+
+class BotBuilderTest {
+
+    @Test
+    fun `test positive connect`(): Unit = runBlocking {
+
+        //TODO 需要实现模拟协议，不做。
+        val client = suspendCoroutine<WebSocketServer> {
+            val o: WebSocketServer = object : WebSocketServer(InetSocketAddress(3001)) {
+                override fun onOpen(conn: WebSocket?, handshake: ClientHandshake?) {
+
+                }
+
+                override fun onClose(conn: WebSocket?, code: Int, reason: String?, remote: Boolean) {
+                }
+
+                override fun onMessage(conn: WebSocket?, message: String?) {
+//                    {"action":"get_version_info","echo":0}
+                    val json = Gson().fromJson(message, JsonObject::class.java)
+                    val echo = json["echo"].asJsonPrimitive.asInt
+                    conn!!.send(JsonObject().apply {
+                        addProperty("status","ok")
+                        addProperty("echo", echo)
+                        add("data", JsonObject().apply {
+                            addProperty("protocol_version", "v11")
+                        })
+                    }.toString())
+                }
+
+                override fun onError(conn: WebSocket?, ex: Exception?) {
+                }
+
+                override fun onStart() {
+                    it.resume(this)
+                }
+            }
+            o.start()
+        }
+        (1..3).map {
+            println("尝试连接bot$it")
+            val bot = BotBuilder.positive("ws://localhost:3001").connect()
+            println("bot$it 已经连接到后端")
+        }
+    }
+
+    @Test
+    fun `test reversed connect`() {
+    }
+}


### PR DESCRIPTION
**在提出此拉取请求时，我确认了以下几点（请复选框）：**

- [x] 我已阅读并理解[[贡献文档](https://github.com/MrXiaoM/Overflow/tree/main/docs/contributing)](https://github.com/MrXiaoM/Overflow/tree/main/docs/contributing)。
- [x] 我已检查没有与此请求重复的 Pull Requests。
- [x] 我已经考虑过，并确认这份呈件对其他人很有价值。
- [x] 我接受此提交可能不会被使用，并根据维护人员的意愿关闭 Pull Requests。

**填写PR内容：**

使上层API无感实现反向WebSocket多实例

**进度**

- [x] 设计正反向无关的`OneBotProducer`
  - [x] API
  - [x] 测试
- [x] 将`OneBotProducer`替换到`OverFlowImpl.start0`中
  - [x] API
  - [ ] 测试