### PR TITLE
 修复在反向ws模式下，由于重新设置wrapper时的作用域问题导致无法获取好友列表的问题

### DIFF
--- a/onebot/build.gradle.kts
+++ b/onebot/build.gradle.kts
@@ -32,6 +32,7 @@ dependencies {
     annotationProcessor("org.java-websocket:Java-WebSocket:1.5.7")
     annotationProcessor("org.projectlombok:lombok:1.18.26")
     testCompileOnly("org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm:1.6.4")
+    implementation("ch.qos.logback:logback-classic:1.4.14")
     testImplementation("org.junit.jupiter:junit-jupiter:5.8.1")
     testImplementation(kotlin("test"))
 }

--- a/onebot/build.gradle.kts
+++ b/onebot/build.gradle.kts
@@ -32,7 +32,7 @@ dependencies {
     annotationProcessor("org.java-websocket:Java-WebSocket:1.5.7")
     annotationProcessor("org.projectlombok:lombok:1.18.26")
     testCompileOnly("org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm:1.6.4")
-    implementation("ch.qos.logback:logback-classic:1.4.14")
+    testImplementation("ch.qos.logback:logback-classic:1.4.14")
     testImplementation("org.junit.jupiter:junit-jupiter:5.8.1")
     testImplementation(kotlin("test"))
 }

--- a/onebot/src/test/java/client/connection/OneBotProducerTest.kt
+++ b/onebot/src/test/java/client/connection/OneBotProducerTest.kt
@@ -9,6 +9,25 @@ import kotlin.time.Duration.Companion.seconds
 
 class OneBotProducerTest {
 
+    /**
+     * 请勿在CI里使用该test。
+     * 启动反向ws实例，强行停止后再次connect，awaitNewBotConnection()应该会返回一个bot链接。
+     * 这个bot的id是懒加载的，这个我也不太清楚
+     */
+    @Test
+    fun `test connection no mock`(): Unit = runBlocking {
+        val producer = ConnectFactory.create(
+            BotConfig(
+                reversedPort = 3001
+            )
+        ).createProducer()
+        while (true) {
+            println("waiting connect")
+            val bot = producer.awaitNewBotConnection()
+            println("新bot加入连接:${bot?.id}")
+        }
+    }
+
     @Test
     fun `positive connection should be connect once`(): Unit = runBlocking {
         val job1 = launch {
@@ -64,6 +83,7 @@ class OneBotProducerTest {
         }
         jobs.join()
     }
+
     @Test
     fun `should be called when server closing`(): Unit = runBlocking {
         val factory = ConnectFactory.create(

--- a/onebot/src/test/resources/logback.xml
+++ b/onebot/src/test/resources/logback.xml
@@ -1,0 +1,13 @@
+<configuration>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{YYYY-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="debug">
+        <appender-ref ref="STDOUT"/>
+    </root>
+    <logger name="org.eclipse.jetty" level="INFO"/>
+    <logger name="io.netty" level="INFO"/>
+</configuration>

--- a/overflow-core-all/build.gradle.kts
+++ b/overflow-core-all/build.gradle.kts
@@ -8,10 +8,17 @@ setupMavenCentralPublication {
     artifact(tasks.kotlinSourcesJar)
 }
 
+tasks.test {
+    useJUnitPlatform()
+}
+
 dependencies {
     api(project(":onebot"))
     api(project(":overflow-core-api"))
     api(project(":overflow-core"))
+    testCompileOnly("net.mamoe:mirai-core-api:2.16.0")
+    testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.8.1")
+    testImplementation("org.junit.jupiter:junit-jupiter-api:5.11.0")
 }
 
 tasks {

--- a/overflow-core-all/build.gradle.kts
+++ b/overflow-core-all/build.gradle.kts
@@ -17,8 +17,9 @@ dependencies {
     api(project(":overflow-core-api"))
     api(project(":overflow-core"))
     testCompileOnly("net.mamoe:mirai-core-api:2.16.0")
+
     testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.8.1")
-    testImplementation("org.junit.jupiter:junit-jupiter-api:5.11.0")
+    testImplementation("org.junit.jupiter:junit-jupiter:5.11.0")
 }
 
 tasks {

--- a/overflow-core-all/src/test/kotlin/OverFlowTest.kt
+++ b/overflow-core-all/src/test/kotlin/OverFlowTest.kt
@@ -1,4 +1,6 @@
 import kotlinx.coroutines.runBlocking
+import net.mamoe.mirai.event.events.GroupMessageEvent
+import net.mamoe.mirai.event.syncFromEvent
 import org.junit.jupiter.api.Test
 import top.mrxiaom.overflow.BotBuilder
 
@@ -12,6 +14,11 @@ class OverFlowTest {
             val bot = builder.connect()
             if (bot !== null) {
                 println("新bot加入连接:${bot}")
+                //确保重新连接后event可以正常接收
+                //这里建议使用GlobalEventChannel避免重复注册的问题
+                bot.eventChannel.subscribeAlways<GroupMessageEvent> {
+                    println(it)
+                }
             }
         }
     }

--- a/overflow-core-all/src/test/kotlin/OverFlowTest.kt
+++ b/overflow-core-all/src/test/kotlin/OverFlowTest.kt
@@ -1,0 +1,18 @@
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.Test
+import top.mrxiaom.overflow.BotBuilder
+
+class OverFlowTest {
+    @Test
+    fun `should be reconnect successfully`(): Unit = runBlocking {
+        val builder = BotBuilder.reversed(3001)
+
+        while (true) {
+            println("等待连接中...")
+            val bot = builder.connect()
+            if (bot !== null) {
+                println("新bot加入连接:${bot}")
+            }
+        }
+    }
+}

--- a/overflow-core/src/main/kotlin/top/mrxiaom/overflow/internal/contact/BotWrapper.kt
+++ b/overflow-core/src/main/kotlin/top/mrxiaom/overflow/internal/contact/BotWrapper.kt
@@ -235,12 +235,13 @@ internal class BotWrapper private constructor(
             configuration: BotConfiguration? = null,
             workingDir: (Long.() -> File)? = null
         ): BotWrapper {
+            val newBot = this
             // also refresh bot id
             val result = getLoginInfo()
             val json = result.json.data ?: JsonObject()
             val loginInfo = result.data ?: throw IllegalStateException("无法获取机器人账号信息")
             return (net.mamoe.mirai.Bot.getInstanceOrNull(id) as? BotWrapper)?.apply {
-                implBot = impl
+                implBot = newBot
                 updateContacts()
             } ?: run {
                 val botConfiguration = configuration ?: defaultBotConfiguration


### PR DESCRIPTION
**在提出此拉取请求时，我确认了以下几点（请复选框）：**

- [x] 我已阅读并理解[贡献文档](https://github.com/MrXiaoM/Overflow/tree/main/docs/contributing)。
- [x] 我已检查没有与此请求重复的 Pull Requests。
- [x] 我已经考虑过，并确认这份呈件对其他人很有价值。
- [x] 我接受此提交可能不会被使用，并根据维护人员的意愿关闭 Pull Requests。

<!-- 以上任意一项未勾选，Pull Requests 将会被无理由关闭，[x] 为已勾选，[ ] 为未勾选 -->
<!-- 以上任意一项未勾选，Pull Requests 将会被无理由关闭，[x] 为已勾选，[ ] 为未勾选 -->
<!-- 以上任意一项未勾选，Pull Requests 将会被无理由关闭，[x] 为已勾选，[ ] 为未勾选 -->

**填写PR内容：**
挺抽象的这个错误。一开始以为是onebot库问题。。。
![image](https://github.com/user-attachments/assets/1ca08c05-18ae-46ff-a9cf-68d26fe30d9b)
