### PR TITLE
feat: ✨ 支持提前解析含content字段的type为forward类型的消息

### DIFF
--- a/overflow-core/src/test/kotlin/ForwardMessageTest.kt
+++ b/overflow-core/src/test/kotlin/ForwardMessageTest.kt
@@ -1,0 +1,129 @@
+import cn.evolvefield.onebot.sdk.response.group.ForwardMsgResp
+import cn.evolvefield.onebot.sdk.util.JsonHelper.gson
+import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.decodeFromString
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import net.mamoe.mirai.message.data.ForwardMessage
+import net.mamoe.mirai.message.data.MessageChain
+import org.junit.jupiter.api.Test
+import top.mrxiaom.overflow.contact.RemoteBot
+import top.mrxiaom.overflow.contact.RemoteBot.Companion.asRemoteBot
+import top.mrxiaom.overflow.internal.message.OnebotMessages
+
+class ForwardMessageTest {
+    private val mockBot = object : RemoteBot {
+        override val appName: String
+            get() = "test"
+        override val appVersion: String
+            get() = "V1.0.0"
+        override val noPlatform: Boolean
+            get() = false
+
+        override suspend fun executeAction(actionPath: String, params: String?): String {
+            TODO("Not yet implemented")
+        }
+
+        override fun sendRawWebSocketMessage(message: String) {
+            TODO("Not yet implemented")
+        }
+
+        override fun sendRawWebSocketMessage(message: ByteArray) {
+            TODO("Not yet implemented")
+        }
+
+        override suspend fun getMsg(messageId: Int): MessageChain? {
+            TODO("Not yet implemented")
+        }
+
+    }
+
+    @Test
+    //仅用于将OnebotMessages.kt#425行的代码做测试，防止出现bug
+    fun testForwardCast() {
+        val it = Json.decodeFromString<JsonObject>(
+        """
+            {
+                "id": "7436377759204399490",
+                "content": [
+                    {
+                        "self_id": 3405637452,
+                        "user_id": 485184047,
+                        "time": 1731415740,
+                        "message_id": 726892516,
+                        "message_seq": 726892516,
+                        "real_id": 726892516,
+                        "message_type": "group",
+                        "sender": {
+                            "user_id": 485184047,
+                            "nickname": "上亦下心",
+                            "card": ""
+                        },
+                        "raw_message": "1",
+                        "font": 14,
+                        "sub_type": "normal",
+                        "message": [
+                            {
+                                "type": "text",
+                                "data": {
+                                    "text": "1"
+                                }
+                            }
+                        ],
+                        "message_format": "array",
+                        "post_type": "message",
+                        "group_id": 284840486
+                    },
+                    {
+                        "self_id": 3405637452,
+                        "user_id": 485184047,
+                        "time": 1731415746,
+                        "message_id": 1835533293,
+                        "message_seq": 1835533293,
+                        "real_id": 1835533293,
+                        "message_type": "group",
+                        "sender": {
+                            "user_id": 485184047,
+                            "nickname": "上亦下心",
+                            "card": ""
+                        },
+                        "raw_message": "1",
+                        "font": 14,
+                        "sub_type": "normal",
+                        "message": [
+                            {
+                                "type": "text",
+                                "data": {
+                                    "text": "1"
+                                }
+                            }
+                        ],
+                        "message_format": "array",
+                        "post_type": "message",
+                        "group_id": 284840486
+                    }
+                ]
+            }
+        """
+        )
+
+        val resp = runBlocking {
+            gson.fromJson(
+                it.toString(),
+                ForwardMsgResp::class.java
+            )
+        }
+        val result = runBlocking {
+            resp.message.map {
+                val msg = OnebotMessages.deserializeFromOneBot(mockBot, it.message)
+                ForwardMessage.Node(
+                    it.sender!!.userId,
+                    it.time,
+                    it.sender!!.nickname.takeIf(String::isNotEmpty) ?: "QQ用户",
+                    msg
+                )
+            }
+        }
+        println(result)
+    }
+}


### PR DESCRIPTION
**在提出此拉取请求时，我确认了以下几点（请复选框）：**

- [x] 我已阅读并理解[贡献文档](https://github.com/MrXiaoM/Overflow/tree/main/docs/contributing)。
- [x] 我已检查没有与此请求重复的 Pull Requests。
- [ ] 我已经考虑过，并确认这份呈件对其他人很有价值。
- [x] 我接受此提交可能不会被使用，并根据维护人员的意愿关闭 Pull Requests。

**填写PR内容：**
Napcat上总会爆合并转发错误：

```log
2024-11-12 21:42:22.594 [DefaultDispatcher-worker-3] WARN  top.mrxiaom.overflow.OverflowAPI - 解析消息 forward -> {"id":"7436387625315107617","content":[{"self_id":3405637452,"user_id":485184047,"time":1731415740,"message_id":315011686,"message_seq":315011686,"real_id":315011686,"message_type":"group","sender":{"user_id":485184047,"nickname":"上亦下心","card":""},"raw_message":"1","font":14,"sub_type":"normal","message":[{"type":"text","data":{"text":"1"}}],"message_format":"array","post_type":"message","group_id":284840486},{"self_id":3405637452,"user_id":485184047,"time":1731415746,"message_id":1377545730,"message_seq":1377545730,"real_id":1377545730,"message_type":"group","sender":{"user_id":485184047,"nickname":"上亦下心","card":""},"raw_message":"1","font":14,"sub_type":"normal","message":[{"type":"text","data":{"text":"1"}}],"message_format":"array","post_type":"message","group_id":284840486}]} 时出现错误 (NapCat.Onebot v2.6.27)
java.lang.IllegalStateException: 无法下载转发消息，详见网络日志 (logs/onebot/*.log
	at top.mrxiaom.overflow.internal.Overflow.downloadForwardMessage(Overflow.kt:439)
	at top.mrxiaom.overflow.internal.Overflow$downloadForwardMessage$1.invokeSuspend(Overflow.kt)
	at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
	at kotlinx.coroutines.internal.ScopeCoroutine.afterResume(Scopes.kt:28)
	at kotlinx.coroutines.AbstractCoroutine.resumeWith(AbstractCoroutine.kt:99)
	at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:46)
	at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:102)
	at kotlinx.coroutines.internal.LimitedDispatcher$Worker.run(LimitedDispatcher.kt:111)
	at kotlinx.coroutines.scheduling.TaskImpl.run(Tasks.kt:99)
	at kotlinx.coroutines.scheduling.CoroutineScheduler.runSafely(CoroutineScheduler.kt:584)
	at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.executeTask(CoroutineScheduler.kt:811)
	at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.runWorker(CoroutineScheduler.kt:715)
	at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.run(CoroutineScheduler.kt:702)
```

经调试**很可能**是napcat对`get_forward_msg`的请求不返回的缘故(~~至少我查遍napcat的文件日志也未发现napcat向overflow推送`get_forward_msg`的返回~~)

而napcat是在type为forward的消息内提前塞了content的。这意味着可以通过提前解析来抑制本该解析失败的消息。

> 需要注意的是，若含有`reply`等消息，此时的Overflow仍会发送`get_msg`请求，**目前也未发现`get_msg`的返回**
> 对于这种方式，我无能为力