### PR TITLE
支持GroupNameChangeNoticeEvent事件

### DIFF
--- a/onebot/src/main/kotlin/sdk/event/EventMap.kt
+++ b/onebot/src/main/kotlin/sdk/event/EventMap.kt
@@ -33,6 +33,7 @@ object EventMap {
         "group_increase" to GroupIncreaseNoticeEvent::class,
         "group_ban" to GroupBanNoticeEvent::class,
         "group_recall" to GroupMsgDeleteNoticeEvent::class,
+        "group_name_change" to GroupNameChangeNoticeEvent::class,
         "notify" to NotifyNoticeEvent::class,
         "lucky_king" to GroupLuckyKingNoticeEvent::class,
         "honor" to GroupHonorChangeNoticeEvent::class,

--- a/onebot/src/main/kotlin/sdk/event/notice/group/GroupNameChangeNoticeEvent.kt
+++ b/onebot/src/main/kotlin/sdk/event/notice/group/GroupNameChangeNoticeEvent.kt
@@ -1,0 +1,23 @@
+package cn.evolvefield.onebot.sdk.event.notice.group
+
+import cn.evolvefield.onebot.sdk.event.notice.NoticeEvent
+import com.google.gson.annotations.SerializedName
+import lombok.AllArgsConstructor
+import lombok.Data
+import lombok.EqualsAndHashCode
+import lombok.NoArgsConstructor
+import lombok.experimental.SuperBuilder
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@SuperBuilder(toBuilder = true)
+@EqualsAndHashCode(callSuper = true)
+class GroupNameChangeNoticeEvent : NoticeEvent() {
+    @SerializedName("name")
+    var name = ""
+    @SerializedName("group_id")
+    var groupId = 0L
+    @SerializedName("operator_id")
+    var operatorId = 0L
+}

--- a/overflow-core/src/main/kotlin/top/mrxiaom/overflow/internal/listener/group.kt
+++ b/overflow-core/src/main/kotlin/top/mrxiaom/overflow/internal/listener/group.kt
@@ -32,7 +32,7 @@ internal fun addGroupListeners() {
         GroupAdminNoticeListener(),
         GroupEssenceNoticeListener(),
         GroupCardChangeNoticeListener(),
-
+        GroupNameChangeListener()
     ).forEach(EventBus::addListener)
 }
 
@@ -366,6 +366,22 @@ internal class GroupCardChangeNoticeListener : EventListener<GroupCardChangeNoti
         val member = group.queryMember(e.userId) ?: return
         bot.eventDispatcher.broadcastAsync(MemberCardChangeEvent(
             e.cardOld, e.cardNew, member
+        ))
+    }
+}
+internal class GroupNameChangeListener : EventListener<GroupNameChangeNoticeEvent> {
+    override suspend fun onMessage(e: GroupNameChangeNoticeEvent) {
+        val bot = e.bot ?: return
+        if (bot.checkId(e.groupId) {
+                "%onebot 返回了异常的数值 group_id=%value"
+        }) return
+        val group = bot.group(e.groupId)
+        val origin = group.name
+        val new = e.name
+        group.impl.groupName = new
+        val operator = if (e.operatorId <= 0) null else group.queryMember(e.operatorId)
+        bot.eventDispatcher.broadcastAsync(GroupNameChangeEvent(
+                origin, new, group, operator
         ))
     }
 }


### PR DESCRIPTION
**在提出此拉取请求时，我确认了以下几点（请复选框）：**

- [x] 我已阅读并理解[贡献文档](https://github.com/MrXiaoM/Overflow/tree/main/docs/contributing)。
- [x] 我已检查没有与此请求重复的 Pull Requests。
- [x] 我已经考虑过，并确认这份呈件对其他人很有价值。
- [x] 我接受此提交可能不会被使用，并根据维护人员的意愿关闭 Pull Requests。

<!-- 以上任意一项未勾选，Pull Requests 将会被无理由关闭，[x] 为已勾选，[ ] 为未勾选 -->
<!-- 以上任意一项未勾选，Pull Requests 将会被无理由关闭，[x] 为已勾选，[ ] 为未勾选 -->
<!-- 以上任意一项未勾选，Pull Requests 将会被无理由关闭，[x] 为已勾选，[ ] 为未勾选 -->

**填写PR内容：**
来自Lagrange端的推送：
W/Overflow: 接收到来自协议端的未知事件 {"group_id":8724XXXX,"name":"XXXX","notice_type":"group_name_change","time":17310XXXX,"self_id":22487XXXX,"post_type":"notice"}
Overflow不会响应这个消息导致群名会一直不变，于是添加其支持
测试运行良好
![image](https://github.com/user-attachments/assets/6826d8a3-996f-4950-8f55-49b37da80d9a)


