### PR TITLE
修复因握手阶段的错误导致bot无法接受后续连接的问题

### DIFF
--- a/onebot/src/main/kotlin/client/connection/ConnectFactory.kt
+++ b/onebot/src/main/kotlin/client/connection/ConnectFactory.kt
@@ -3,10 +3,7 @@ package cn.evolvefield.onebot.client.connection
 import cn.evolvefield.onebot.client.config.BotConfig
 import cn.evolvefield.onebot.client.core.Bot
 import cn.evolvefield.onebot.client.handler.ActionHandler
-import kotlinx.coroutines.CoroutineName
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.CancellationException
-import kotlinx.coroutines.Job
+import kotlinx.coroutines.*
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import java.net.InetSocketAddress
@@ -24,7 +21,7 @@ import java.net.URI
  */
 class ConnectFactory private constructor(
     private val config: BotConfig,
-    parent: Job?,
+    private val parent: Job?,
     private val logger: Logger,
 ) {
     private val actionHandler: ActionHandler = ActionHandler(parent, logger)
@@ -96,8 +93,9 @@ class ConnectFactory private constructor(
 
     @JvmOverloads
     fun createProducer(
-        scope: CoroutineScope = CoroutineScope(CoroutineName("ConnectFactory"))
+        scope0: CoroutineScope = CoroutineScope(CoroutineName("ConnectFactory"))
     ): OneBotProducer {
+        val scope = if (parent == null) scope0 else scope0 + parent
         if (config.isInReverseMode) {
             val address = InetSocketAddress(config.reversedPort)
             return ReversedOneBotProducer(WSServer.create(scope, config, address, logger, actionHandler, config.token))

--- a/overflow-core/src/main/kotlin/top/mrxiaom/overflow/internal/Overflow.kt
+++ b/overflow-core/src/main/kotlin/top/mrxiaom/overflow/internal/Overflow.kt
@@ -93,7 +93,7 @@ class Overflow : IMirai, CoroutineScope, LowLevelApiAccessor, OverflowAPI {
         File(System.getProperty("overflow.config", "overflow.json"))
     }
     val defaultJob: Job? by lazy {
-        if (!miraiConsole) return@lazy null
+        if (!miraiConsole) return@lazy SupervisorJob()
         return@lazy MiraiConsole.job
     }
     val config: Config by lazy {


### PR DESCRIPTION
**在提出此拉取请求时，我确认了以下几点（请复选框）：**

- [x] 我已阅读并理解[贡献文档](https://github.com/MrXiaoM/Overflow/tree/main/docs/contributing)。
- [x] 我已检查没有与此请求重复的 Pull Requests。
- [ ] 我已经考虑过，并确认这份呈件对其他人很有价值。
- [x] 我接受此提交可能不会被使用，并根据维护人员的意愿关闭 Pull Requests。


**填写PR内容：**
出问题的代码片段如下：
```kotlin
val versionInfo = botImpl.getVersionInfo()
if (printInfo) {
    logger.info("协议端版本信息\n${gson.toJson(versionInfo.getAsJsonObject("data"))}")
}
if (botImpl.onebotVersion == 12) {
    throw IllegalStateException("Overflow 暂不支持 Onebot 12")
}
val bot = botImpl.wrap(configuration, workingDir)

return bot.also {
    it.eventDispatcher.broadcastAsync(BotOnlineEvent(bot))
}
```

当`getVersionInfo`和`wrap`内发包出错(如**超时**)时会导致ActionHandler的协程失活，从而无法接受后续bot连接以及无法推送新消息。

于是让创建producer的scope和ConnectFactory绑定在一起

```kotlin
@JvmOverloads
fun createProducer(
   scope0: CoroutineScope = CoroutineScope(CoroutineName("ConnectFactory"))
): OneBotProducer {
   val scope = if (parent == null) scope0 else scope0 + parent
   //...TODO   
}
        
```

同时修改ConnectFactory的scope源头：

```kotlin
val defaultJob: Job? by lazy {
    if (!miraiConsole) return@lazy SupervisorJob()
    return@lazy MiraiConsole.job
}
```

希望可以解决这个问题。

~~可能断连时第二次无法继续连接的bug也会在这里得到修复~~

~~我的bot是直接给ActionHandler暴力写了个SupervisorJob解决的，like this~~

```kotlin
class WSHandler : WebSocketHandler, IAdapter {
    override val scope = CoroutineScope(Dispatchers.IO) + SupervisorJob()

    override val logger: Logger = LoggerFactory.getLogger(ActionHandler::class.java)
    override val actionHandler: ActionHandler = ActionHandler(scope.coroutineContext[Job], logger)

    init {
        top.mrxiaom.overflow.internal.Overflow.setup()
        log.info("Youmu WebSocket 已接管默认Overflow Bot Handler,WSBufferSize: ${System.getProperty("org.apache.tomcat.websocket.DEFAULT_BUFFER_SIZE")}")
    }
}
```