### PR TITLE
管理员人数已满时异常信息与Mirai保持最大一致性

### DIFF
--- a/overflow-core/src/main/kotlin/top/mrxiaom/overflow/internal/contact/MemberWrapper.kt
+++ b/overflow-core/src/main/kotlin/top/mrxiaom/overflow/internal/contact/MemberWrapper.kt
@@ -143,7 +143,7 @@ internal class MemberWrapper(
         checkBotPermissionHighest("设置管理员")
         val count = group.members.count { it.permission == MemberPermission.ADMINISTRATOR }
         if (count >= 15) {
-            throw IllegalStateException("最多可设置15名管理员")
+            throw IllegalStateException("Failed to grant administrator privileges to member ${id} in group ${impl.groupId}")
         }
         if (bot.impl.setGroupAdmin(impl.groupId, id, operation)
             .check("设置 $id 在群聊 ${group.id} 的管理员状态为 $operation")) {


### PR DESCRIPTION
#135 

Mirai源码如下：
https://github.com/mamoe/mirai/blob/dev/mirai-core/src/commonMain/kotlin/contact/NormalMemberImpl.kt#L216-L226 由于此处没有resp的返回值，仅保留前面信息一致

**在提出此拉取请求时，我确认了以下几点（请复选框）：**

- [x] 我已阅读并理解[贡献文档](https://github.com/MrXiaoM/Overflow/tree/main/docs/contributing)。
- [x] 我已检查没有与此请求重复的 Pull Requests。
- [x] 我已经考虑过，并确认这份呈件对其他人很有价值。
- [x] 我接受此提交可能不会被使用，并根据维护人员的意愿关闭 Pull Requests。

<!-- 以上任意一项未勾选，Pull Requests 将会被无理由关闭，[x] 为已勾选，[ ] 为未勾选 -->
<!-- 以上任意一项未勾选，Pull Requests 将会被无理由关闭，[x] 为已勾选，[ ] 为未勾选 -->
<!-- 以上任意一项未勾选，Pull Requests 将会被无理由关闭，[x] 为已勾选，[ ] 为未勾选 -->

**填写PR内容：**


