### PR TITLE
fix incorrect replacement

### DIFF
--- a/overflow-core/src/main/kotlin/cn/evolvefield/onebot/sdk/util/CQCode.kt
+++ b/overflow-core/src/main/kotlin/cn/evolvefield/onebot/sdk/util/CQCode.kt
@@ -50,7 +50,7 @@ object CQCode {
             })
         }
         fun String.decode(): String {
-            return replace("&amp", "&")
+            return replace("&amp;", "&")
                 .replace("&#91;", "[")
                 .replace("&#93;", "]")
         }


### PR DESCRIPTION
**在提出此拉取请求时，我确认了以下几点（请复选框）：**

- [x] 我已阅读并理解[贡献文档](https://github.com/MrXiaoM/Overflow/tree/main/docs/contributing)。
- [x] 我已检查没有与此请求重复的 Pull Requests。
- [x] 我已经考虑过，并确认这份呈件对其他人很有价值。
- [x] 我接受此提交可能不会被使用，并根据维护人员的意愿关闭 Pull Requests。

<!-- 以上任意一项未勾选，Pull Requests 将会被无理由关闭，[x] 为已勾选，[ ] 为未勾选 -->
<!-- 以上任意一项未勾选，Pull Requests 将会被无理由关闭，[x] 为已勾选，[ ] 为未勾选 -->
<!-- 以上任意一项未勾选，Pull Requests 将会被无理由关闭，[x] 为已勾选，[ ] 为未勾选 -->

**填写PR内容：**

修复bot发送的所有消息中 `&` 被错误替换为 `&;` 的问题

```
2025-05-22 11:41:28 D/Onebot: [Recv] <-- {"self_id":***,"user_id":***,"time":1747885288,"message_id":615769083,"message_seq":615769083,"real_id":615769083,"real_seq":"4709034","message_type":"group","sender":{"user_id":***,"nickname":"***","card":"***","role":"admin"},"raw_message":"comb &amp;&amp;&amp;&amp;&amp;","font":14,"sub_type":"normal","message":"comb &amp;&amp;&amp;&amp;&amp;","message_format":"string","post_type":"message","group_id":***}
2025-05-22 11:41:29 D/Onebot: [Send] --> {"action":"send_group_msg","params":{"group_id":***,"message":[{"type":"text","data":{"text":"seed: &;&;&;&;&;\nscore: 254\n10 5 15 19 7 12 4 3 1 9 0 2 16 14 11 13 17 6 18 8\n"}}],"auto_escape":false},"echo":385}
```
