### PR TITLE
fix #155 and broadcast BotJoinGroupEvent.Invite by GroupIncreaseNoticeEvent completely

### DIFF
--- a/overflow-core/src/main/kotlin/top/mrxiaom/overflow/internal/Overflow.kt
+++ b/overflow-core/src/main/kotlin/top/mrxiaom/overflow/internal/Overflow.kt
@@ -612,14 +612,6 @@ class Overflow : IMirai, CoroutineScope, LowLevelApiAccessor, OverflowAPI {
         newInviteJoinGroupRequest.get(eventId)?.also {
             val onebot = bot.asOnebot
             val resp = onebot.impl.setGroupAddRequest(it, "invite", accept, "")
-            if (accept && resp.status == "ok") {
-                val group = onebot.group(groupId)
-                val invitor = group.queryMember(invitorId) ?: return
-                if (!onebot.inviteHandledGroups.contains(groupId)) {
-                    onebot.inviteHandledGroups.add(groupId)
-                    onebot.eventDispatcher.broadcastAsync(BotJoinGroupEvent.Invite(invitor))
-                }
-            }
         }
     }
     //========== Bot Invited Join Group Request 邀请机器人加群请求 END =============

--- a/overflow-core/src/main/kotlin/top/mrxiaom/overflow/internal/contact/BotWrapper.kt
+++ b/overflow-core/src/main/kotlin/top/mrxiaom/overflow/internal/contact/BotWrapper.kt
@@ -62,7 +62,6 @@ internal class BotWrapper private constructor(
     private var groupsInternal: ContactList<GroupWrapper> = ContactList()
     private var otherClientsInternal: ContactList<OtherClientWrapper>? = null
     private var strangersInternal: ContactList<StrangerWrapper> = ContactList()
-    internal val inviteHandledGroups = mutableSetOf<Long>()
 
     suspend fun updateLoginInfo() {
         loginInfo = impl.getLoginInfo().data ?: throw IllegalStateException("刷新机器人信息失败")

--- a/overflow-core/src/main/kotlin/top/mrxiaom/overflow/internal/listener/group.kt
+++ b/overflow-core/src/main/kotlin/top/mrxiaom/overflow/internal/listener/group.kt
@@ -225,8 +225,6 @@ internal fun addGroupListeners() {
             ?: throw IllegalStateException("无法找到群 ${e.groupId} 的成员 ${e.operatorId}")
         // 管理员已同意邀请入群
         if (member.id == bot.id) {
-            if (bot.inviteHandledGroups.contains(group.id)) return@listen
-            bot.inviteHandledGroups.add(group.id)
             bot.eventDispatcher.broadcastAsync(BotJoinGroupEvent.Invite(invitor))
         } else {
             bot.eventDispatcher.broadcastAsync(MemberJoinEvent.Invite(member, invitor))


### PR DESCRIPTION
**在提出此拉取请求时，我确认了以下几点（请复选框）：**

- [x] 我已阅读并理解[贡献文档](https://github.com/MrXiaoM/Overflow/tree/main/docs/contributing)。
- [x] 我已检查没有与此请求重复的 Pull Requests。
- [x] 我已经考虑过，并确认这份呈件对其他人很有价值。
- [x] 我接受此提交可能不会被使用，并根据维护人员的意愿关闭 Pull Requests。

<!-- 以上任意一项未勾选，Pull Requests 将会被无理由关闭，[x] 为已勾选，[ ] 为未勾选 -->
<!-- 以上任意一项未勾选，Pull Requests 将会被无理由关闭，[x] 为已勾选，[ ] 为未勾选 -->
<!-- 以上任意一项未勾选，Pull Requests 将会被无理由关闭，[x] 为已勾选，[ ] 为未勾选 -->

**填写PR内容：**

fix #155 and broadcast BotJoinGroupEvent by GroupIncreaseNoticeEvent completely

完全基于稳定的GroupIncreaseNoticeEvent来广播BotJoinGroupEvent，抛弃基于不稳定的InviteJoinGroupRequest，同时不用考虑二者会重复的问题，修复了#155

根据#155的分析，这样改我认为逻辑上没问题，根据#155评论里的某些原因，本次小改动并未进行本地打包后实机测试，若检查后感觉没问题并合并了，我再下载最新开发版进行实机验证测试
