### PR TITLE
修复MessagePreSendEvent不能修改消息内容的问题

### DIFF
--- a/overflow-core/src/main/kotlin/top/mrxiaom/overflow/internal/contact/FriendWrapper.kt
+++ b/overflow-core/src/main/kotlin/top/mrxiaom/overflow/internal/contact/FriendWrapper.kt
@@ -74,10 +74,11 @@ internal class FriendWrapper(
     }
 
     override suspend fun sendMessage(message: Message): MessageReceipt<Friend> {
-        if (FriendMessagePreSendEvent(this, message).broadcast().isCancelled)
+        val event = FriendMessagePreSendEvent(this, message)
+        if (event.broadcast().isCancelled)
             throw EventCancelledException("消息发送已被取消")
 
-        val messageChain = message.toMessageChain()
+        val messageChain = event.message.toMessageChain()
         val (messageIds, throwable) = bot.sendMessageCommon(this, messageChain)
         val receipt = friendMsg(messageIds, messageChain).receipt(this)
         FriendMessagePostSendEvent(

--- a/overflow-core/src/main/kotlin/top/mrxiaom/overflow/internal/contact/GroupWrapper.kt
+++ b/overflow-core/src/main/kotlin/top/mrxiaom/overflow/internal/contact/GroupWrapper.kt
@@ -207,12 +207,13 @@ internal class GroupWrapper(
     }
 
     override suspend fun sendMessage(message: Message): MessageReceipt<Group> {
-        if (GroupMessagePreSendEvent(this, message).broadcast().isCancelled)
+        val event = GroupMessagePreSendEvent(this, message)
+        if (event.broadcast().isCancelled)
             throw EventCancelledException("消息发送已被取消")
         if (isBotMuted)
             throw BotIsBeingMutedException(this, message)
 
-        val messageChain = message.toMessageChain()
+        val messageChain = event.message.toMessageChain()
         val (messageIds, throwable) = bot.sendMessageCommon(this, messageChain)
         val receipt = groupMsg(messageIds, messageChain).receipt(this)
         GroupMessagePostSendEvent(

--- a/overflow-core/src/main/kotlin/top/mrxiaom/overflow/internal/contact/MemberWrapper.kt
+++ b/overflow-core/src/main/kotlin/top/mrxiaom/overflow/internal/contact/MemberWrapper.kt
@@ -191,10 +191,11 @@ internal class MemberWrapper(
     }
 
     override suspend fun sendMessage(message: Message): MessageReceipt<NormalMember> {
-        if (GroupTempMessagePreSendEvent(this, message).broadcast().isCancelled)
+        val event = GroupTempMessagePreSendEvent(this, message)
+        if (event.broadcast().isCancelled)
             throw EventCancelledException("消息发送已被取消")
 
-        val messageChain = message.toMessageChain()
+        val messageChain = event.message.toMessageChain()
         val (messageIds, throwable) = bot.sendMessageCommon(this, messageChain)
         val receipt = tempMsg(messageIds, messageChain).receipt(this)
         GroupTempMessagePostSendEvent(

--- a/overflow-core/src/main/kotlin/top/mrxiaom/overflow/internal/contact/StrangerWrapper.kt
+++ b/overflow-core/src/main/kotlin/top/mrxiaom/overflow/internal/contact/StrangerWrapper.kt
@@ -56,10 +56,11 @@ internal class StrangerWrapper(
     }
 
     override suspend fun sendMessage(message: Message): MessageReceipt<Stranger> {
-        if (StrangerMessagePreSendEvent(this, message).broadcast().isCancelled)
+        val event = StrangerMessagePreSendEvent(this, message)
+        if (event.broadcast().isCancelled)
             throw EventCancelledException("消息发送已被取消")
 
-        val messageChain = message.toMessageChain()
+        val messageChain = event.message.toMessageChain()
         val (messageIds, throwable) = bot.sendMessageCommon(this, messageChain)
         val receipt = strangerMsg(messageIds, messageChain).receipt(this)
         StrangerMessagePostSendEvent(


### PR DESCRIPTION
**在提出此拉取请求时，我确认了以下几点（请复选框）：**

- [x] 我已阅读并理解[贡献文档](https://github.com/MrXiaoM/Overflow/tree/main/docs/contributing)。
- [x] 我已检查没有与此请求重复的 Pull Requests。
- [x] 我已经考虑过，并确认这份呈件对其他人很有价值。
- [x] 我接受此提交可能不会被使用，并根据维护人员的意愿关闭 Pull Requests。

<!-- 以上任意一项未勾选，Pull Requests 将会被无理由关闭，[x] 为已勾选，[ ] 为未勾选 -->
<!-- 以上任意一项未勾选，Pull Requests 将会被无理由关闭，[x] 为已勾选，[ ] 为未勾选 -->
<!-- 以上任意一项未勾选，Pull Requests 将会被无理由关闭，[x] 为已勾选，[ ] 为未勾选 -->

**填写PR内容：**

修复在 `MessagePreSendEvent` 中更改 `message` 内容但无法生效的问题。用于解决部分插件修改机器人发送的消息内容（如消息审核功能），但机器人仍然发送原消息的问题。
已在群聊和私聊场景下进行测试，功能正常
