### PR TITLE
完善 FolderWrapper.createFolder 和 FolderWrapper.moveTo

### DIFF
--- a/overflow-core/src/main/kotlin/cn/evolvefield/onebot/client/core/Bot.kt
+++ b/overflow-core/src/main/kotlin/cn/evolvefield/onebot/client/core/Bot.kt
@@ -15,6 +15,7 @@ import cn.evolvefield.onebot.sdk.response.contact.LoginInfoResp
 import cn.evolvefield.onebot.sdk.response.contact.StrangerInfoResp
 import cn.evolvefield.onebot.sdk.response.ext.CreateGroupFileFolderResp
 import cn.evolvefield.onebot.sdk.response.ext.GetFileResp
+import cn.evolvefield.onebot.sdk.response.ext.MoveGroupFIleResp
 import cn.evolvefield.onebot.sdk.response.ext.SetGroupReactionResp
 import cn.evolvefield.onebot.sdk.response.ext.UploadGroupFileResp
 import cn.evolvefield.onebot.sdk.response.group.*
@@ -1034,6 +1035,34 @@ internal class Bot(
             addProperty("name", name)
             addProperty("folder_name", name)
             addProperty("parent_id", parentId)
+        }
+        val result = actionHandler.action(this, action, params)
+        return result.withToken()
+    }
+
+    /**
+     * 移动群文件
+     * @param groupId 群号
+     * @param fileId 文件ID
+     * @param currentParentDirectoryId 目前父文件夹ID 参考 Folder 对象
+     * @param targetParentDirectoryId 目标父文件夹ID 参考 Folder 对象
+     * @param context  Onebot 主动操作的上下文
+     */
+    @JvmBlockingBridge
+    @JvmOverloads
+    suspend fun moveGroupFIle(
+        groupId: Long,
+        fileId: String,
+        currentParentDirectoryId: String,
+        targetParentDirectoryId: String,
+        context: Context = {},
+    ): ActionData<MoveGroupFIleResp> {
+        val action = context.build(ActionPathEnum.MOVE_GROUP_FILE)
+        val params = JsonObject().apply {
+            addProperty("group_id", groupId)
+            addProperty("file_id", fileId)
+            addProperty("current_parent_directory", currentParentDirectoryId)
+            addProperty("target_parent_directory", targetParentDirectoryId)
         }
         val result = actionHandler.action(this, action, params)
         return result.withToken()

--- a/overflow-core/src/main/kotlin/cn/evolvefield/onebot/sdk/enums/ActionPathEnum.kt
+++ b/overflow-core/src/main/kotlin/cn/evolvefield/onebot/sdk/enums/ActionPathEnum.kt
@@ -263,4 +263,9 @@ enum class ActionPathEnum(
      * 创建群文件夹
      */
     CREATE_GROUP_FILE_FOLDER("create_group_file_folder"),
+
+    /**
+     * 移动群文件
+     */
+    MOVE_GROUP_FILE("move_group_file"),
 }

--- a/overflow-core/src/main/kotlin/cn/evolvefield/onebot/sdk/response/ext/CreateGroupFileFolderResp.kt
+++ b/overflow-core/src/main/kotlin/cn/evolvefield/onebot/sdk/response/ext/CreateGroupFileFolderResp.kt
@@ -3,9 +3,22 @@ package cn.evolvefield.onebot.sdk.response.ext
 import com.google.gson.annotations.SerializedName
 
 /**
- * LLOnebot
+ * LLOnebot, NapCat
  */
 class CreateGroupFileFolderResp {
     @SerializedName("folder_id")
     var folderId = ""
+
+    @SerializedName("groupItem")
+    var groupItem: GroupItem? = null
+
+    class GroupItem{
+        @SerializedName("folderInfo")
+        var folderInfo: FolderInfo? = null
+
+        class FolderInfo{
+            @SerializedName("folderId")
+            var folderId = ""
+        }
+    }
 }

--- a/overflow-core/src/main/kotlin/cn/evolvefield/onebot/sdk/response/ext/MoveGroupFIleResp.kt
+++ b/overflow-core/src/main/kotlin/cn/evolvefield/onebot/sdk/response/ext/MoveGroupFIleResp.kt
@@ -1,0 +1,11 @@
+package cn.evolvefield.onebot.sdk.response.ext
+
+import com.google.gson.annotations.SerializedName
+
+/**
+ * NapCat
+ */
+class MoveGroupFIleResp {
+    @SerializedName("ok")
+    var ok: Boolean = false
+}

--- a/overflow-core/src/main/kotlin/top/mrxiaom/overflow/internal/contact/data/RemoteFilesWrapper.kt
+++ b/overflow-core/src/main/kotlin/top/mrxiaom/overflow/internal/contact/data/RemoteFilesWrapper.kt
@@ -294,7 +294,7 @@ internal class FileWrapper(
         val success = impl.moveGroupFIle(contact.id, id, absolutePath, folder.absolutePath).data?.ok ?: false
         when (contact.bot.appName.lowercase()) {
             "napcat" -> return success
-            else -> throw PermissionDeniedException("当前 Onebot 实现不支持获取文件夹创建回执")
+            else -> throw PermissionDeniedException("当前 Onebot 实现不支持移动文件")
         }
     }
 

--- a/overflow-core/src/main/kotlin/top/mrxiaom/overflow/internal/contact/data/RemoteFilesWrapper.kt
+++ b/overflow-core/src/main/kotlin/top/mrxiaom/overflow/internal/contact/data/RemoteFilesWrapper.kt
@@ -110,15 +110,22 @@ internal class FolderWrapper(
     override suspend fun createFolder(name: String): AbsoluteFolder {
         if (name.isEmpty()) throw IllegalArgumentException("子目录名称不能为空")
         if (name.matches(Regex(":*?\"<>|"))) throw IllegalArgumentException("不能在非根目录下创建子目录")
-        val result = contact.bot.impl.createGroupFileFolder(contact.id, name, id)
-        val data = result.data
-        if (data != null && data.folderId.isNotEmpty()) {
-            val time = currentTimeSeconds()
-            val folder = FolderWrapper(contact, this, data.folderId, name, time, time, contact.bot.id, 0)
-            folders.add(folder)
-            return folder
+
+        // 与 mirai 行为保持一致
+        this.resolveFolder(name)?.let {
+            return it
         }
-        throw PermissionDeniedException("当前 Onebot 实现不支持获取文件夹创建回执")
+        val result = contact.bot.impl.createGroupFileFolder(contact.id, name, id)
+        val data = result.data ?: throw PermissionDeniedException("当前 Onebot 实现不支持获取文件夹创建回执")
+        val folderId = if (data.folderId.isNotEmpty()) {
+            data.folderId
+        } else if (data.groupItem?.folderInfo?.folderId?.isNotEmpty() ?: false) {
+            data.groupItem?.folderInfo?.folderId!!
+        } else throw PermissionDeniedException("当前 Onebot 实现不支持获取文件夹创建回执")
+        val time = currentTimeSeconds()
+        val folder = FolderWrapper(contact, this, folderId, name, time, time, contact.bot.id, 0)
+        folders.add(folder)
+        return folder
     }
 
     @JavaFriendlyAPI
@@ -284,7 +291,11 @@ internal class FileWrapper(
     }
 
     override suspend fun moveTo(folder: AbsoluteFolder): Boolean {
-        TODO("暂无移动文件实现")
+        val success = impl.moveGroupFIle(contact.id, id, absolutePath, folder.absolutePath).data?.ok ?: false
+        when (contact.bot.appName.lowercase()) {
+            "napcat" -> return success
+            else -> throw PermissionDeniedException("当前 Onebot 实现不支持获取文件夹创建回执")
+        }
     }
 
     override suspend fun refresh(): Boolean {


### PR DESCRIPTION
…接从缓存获取（与 mirai 的 createFolder 行为一致）

**在提出此拉取请求时，我确认了以下几点（请复选框）：**

- [x] 我已阅读并理解[贡献文档](https://github.com/MrXiaoM/Overflow/tree/main/docs/contributing)。
- [x] 我已检查没有与此请求重复的 Pull Requests。
- [x] 我已经考虑过，并确认这份呈件对其他人很有价值。
- [x] 我接受此提交可能不会被使用，并根据维护人员的意愿关闭 Pull Requests。

<!-- 以上任意一项未勾选，Pull Requests 将会被无理由关闭，[x] 为已勾选，[ ] 为未勾选 -->
<!-- 以上任意一项未勾选，Pull Requests 将会被无理由关闭，[x] 为已勾选，[ ] 为未勾选 -->
<!-- 以上任意一项未勾选，Pull Requests 将会被无理由关闭，[x] 为已勾选，[ ] 为未勾选 -->

**填写PR内容：**

### createFolder
1. 添加 NapCat 支持
2. 当文件夹已经存在时，直接获取（与 mirai 的行为一致）
NapCat 回执解析可能还需要进一步修改，有任何意见请提出

### moveTo
添加 NapCat 支持