### PR TITLE
保存图片消息的原始 Json 数据

### DIFF
--- a/overflow-core/src/main/kotlin/top/mrxiaom/overflow/internal/message/OnebotMessages.kt
+++ b/overflow-core/src/main/kotlin/top/mrxiaom/overflow/internal/message/OnebotMessages.kt
@@ -357,6 +357,13 @@ internal object OnebotMessages {
                             } else {
                                 add(image)
                             }
+
+                            /**
+                             * 保存图片原始 Json 数据到 [WrappedImage.rawJson]
+                             */
+                            if (image is WrappedImage) {
+                                image.rawJson = data
+                            }
                         }
 
                         "record" -> add(audioFromFile(data["file"].string))

--- a/overflow-core/src/main/kotlin/top/mrxiaom/overflow/internal/message/data/WrappedImageProtocol.kt
+++ b/overflow-core/src/main/kotlin/top/mrxiaom/overflow/internal/message/data/WrappedImageProtocol.kt
@@ -2,6 +2,7 @@ package top.mrxiaom.overflow.internal.message.data
 
 import cn.evolvefield.onebot.client.util.fileType
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.JsonObject
 import net.mamoe.mirai.Bot
 import net.mamoe.mirai.contact.Contact
 import net.mamoe.mirai.message.data.Image
@@ -43,6 +44,14 @@ internal data class WrappedImage(
     override val width: Int,
     override val height: Int,
 ): Image {
+
+    /**
+     * 图片消息原始 Json 数据
+     *
+     * 用以获取一些非 Onebot 规范定义的数据
+     */
+    var rawJson: JsonObject? = null
+
     private val _stringValue: String? by lazy(LazyThreadSafetyMode.NONE) {
         val fileString = if (url.startsWith("base64://") && url.length > 32) {
             val s = url.replace("base64://", "")


### PR DESCRIPTION
**在提出此拉取请求时，我确认了以下几点（请复选框）：**

- [x] 我已阅读并理解[贡献文档](https://github.com/MrXiaoM/Overflow/tree/main/docs/contributing)。
- [x] 我已检查没有与此请求重复的 Pull Requests。
- [x] 我已经考虑过，并确认这份呈件对其他人很有价值。
- [x] 我接受此提交可能不会被使用，并根据维护人员的意愿关闭 Pull Requests。

<!-- 以上任意一项未勾选，Pull Requests 将会被无理由关闭，[x] 为已勾选，[ ] 为未勾选 -->
<!-- 以上任意一项未勾选，Pull Requests 将会被无理由关闭，[x] 为已勾选，[ ] 为未勾选 -->
<!-- 以上任意一项未勾选，Pull Requests 将会被无理由关闭，[x] 为已勾选，[ ] 为未勾选 -->

**填写PR内容：**

将图片消息的原始 Json 数据保存到 WrappedImage 类中，用以获取一些非 Onebot 协议定义的数据，如 “summary”。
